### PR TITLE
Python and docker fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM rocker/r-ver:4	
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pandas python3-numpy python3-matplotlib python3-seaborn python3-sklearn
+RUN R -e 'install.packages(c("missForest", "glmnet", "caret", "doParallel", "dbplyr", "randomforest"))'
+RUN R -e 'if (!require("BiocManager", quietly = TRUE)) install.packages("BiocManager"); BiocManager::install("biomaRt"); '

--- a/bin/method2_function.py
+++ b/bin/method2_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 # -*- coding: utf-8 -*-

--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,7 @@
 #!/usr/bin/env nextflow
 
+nextflow.enable.dsl = 2
+
 /* Prints help when asked for and exits */
 def helpMessage() {
     log.info"""
@@ -90,7 +92,7 @@ process METHOD2 {
 
     script:
     """
-    python /opt/cosmo/method2_function.py \\
+    method2_function.py \\
         -d1 ${d1_file} \\
         -d2 ${d2_file} \\
         -s ${samplefile} \\


### PR DESCRIPTION
Hi COSMO authors

At the moment, I don't think there is a way of users knowing what software is being loaded inside the Docker container used to run each of the COSMO tasks. Included in this PR is a minimal Dockerfile that can be used to build an image suitable for the docker tasks.

Also included is a change to use the python script bundled in this repository rather than the docker image for the method 2 process.